### PR TITLE
fix: sort by iso date

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,8 +59,8 @@ export async function analyzeCommits(
 
   const committerDates = filteredCommits
     .map(({ committerDate }) => committerDate)
+    .sort() // sort before converting to moment
     .map((date) => moment(date))
-    .sort();
 
   committerDates.forEach((date) => {
     logger.log(`committerDate: ${date.format()}`);


### PR DESCRIPTION
Cannot sort on `moment[]`. https://stackoverflow.com/questions/28013045/sort-array-by-date-gives-unexpected-results